### PR TITLE
Add prettier check to format non-python code

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -12,3 +12,8 @@ repos:
   rev: 24.2.0
   hooks:
   - id: black
+- repo: https://github.com/pre-commit/mirrors-prettier
+  rev: "v3.1.0"
+  hooks:
+    - id: prettier
+      types_or: [yaml, markdown, html, css, scss, javascript, json]

--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,19 +1,19 @@
 repos:
-- repo: https://github.com/pre-commit/pre-commit-hooks
-  rev: v4.5.0
-  hooks:
-  - id: check-merge-conflict
-  - id: debug-statements
-  - id: no-commit-to-branch
-    args: [--branch, main]
-  - id: requirements-txt-fixer
-  - id: trailing-whitespace
-- repo: https://github.com/psf/black
-  rev: 24.2.0
-  hooks:
-  - id: black
-- repo: https://github.com/pre-commit/mirrors-prettier
-  rev: "v3.1.0"
-  hooks:
-    - id: prettier
-      types_or: [yaml, markdown, html, css, scss, javascript, json]
+  - repo: https://github.com/pre-commit/pre-commit-hooks
+    rev: v4.5.0
+    hooks:
+      - id: check-merge-conflict
+      - id: debug-statements
+      - id: no-commit-to-branch
+        args: [--branch, main]
+      - id: requirements-txt-fixer
+      - id: trailing-whitespace
+  - repo: https://github.com/psf/black
+    rev: 24.2.0
+    hooks:
+      - id: black
+  - repo: https://github.com/pre-commit/mirrors-prettier
+    rev: "v3.1.0"
+    hooks:
+      - id: prettier
+        types_or: [yaml, markdown, html, css, scss, javascript, json]

--- a/environment.yml
+++ b/environment.yml
@@ -408,4 +408,4 @@ dependencies:
   - zlib==1.2.13
   - zstd==1.5.2
   - pip:
-    - sphinxcontrib-tikz==0.4.16
+      - sphinxcontrib-tikz==0.4.16

--- a/notebooks/_config.yml
+++ b/notebooks/_config.yml
@@ -21,9 +21,9 @@ bibtex_bibfiles:
 
 # Information about where the book exists on the web
 repository:
-  url: https://github.com/tkoyama010/notebooks  # Online location of your book
-  path_to_book: notebooks  # Optional path to your book, relative to the repository root
-  branch: master  # Which branch of the repository should be used when creating links (optional)
+  url: https://github.com/tkoyama010/notebooks # Online location of your book
+  path_to_book: notebooks # Optional path to your book, relative to the repository root
+  branch: master # Which branch of the repository should be used when creating links (optional)
 
 # Add GitHub buttons to your book
 # See https://jupyterbook.org/customize/config.html#add-a-link-to-your-repository

--- a/notebooks/_toc.yml
+++ b/notebooks/_toc.yml
@@ -4,11 +4,11 @@
 format: jb-book
 root: index
 chapters:
-- file: notebooks/hello-world
-- file: notebooks/titanic
-- file: notebooks/hello-getfem
-- file: notebooks/hello-pyvista
-- file: notebooks/hello-tikz
-- file: notebooks/integration-getfem
-- file: notebooks/torsion-getfem
-- file: notebooks/stress-transformations
+  - file: notebooks/hello-world
+  - file: notebooks/titanic
+  - file: notebooks/hello-getfem
+  - file: notebooks/hello-pyvista
+  - file: notebooks/hello-tikz
+  - file: notebooks/integration-getfem
+  - file: notebooks/torsion-getfem
+  - file: notebooks/stress-transformations

--- a/notebooks/index.md
+++ b/notebooks/index.md
@@ -8,4 +8,5 @@ It does not go in-depth into any particular topic - check out [the Jupyter Book 
 Check out the content pages bundled with this sample book to see more.
 
 ```{tableofcontents}
+
 ```


### PR DESCRIPTION
### Overview

<!-- Please insert a high-level description of this pull request here. -->
The [prettier](https://prettier.io/) tool can format a large number of different file types. Scientific Python Library Development Guide recommends using prettier to format non-python code.

<!-- Be sure to link other PRs or issues that relate to this PR here. -->

<!-- If this fully addresses an issue, please use the keyword `resolves` in front of that issue number. -->


### Details

- https://learn.scientific-python.org/development/guides/style/#prettier
